### PR TITLE
Perf tweaks to prevent excessive calls to getHeaderId()

### DIFF
--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/HeaderPositionCalculator.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/HeaderPositionCalculator.java
@@ -36,28 +36,21 @@ public class HeaderPositionCalculator {
    * @see {@link StickyRecyclerHeadersAdapter#getHeaderId(int)}
    */
   public boolean hasNewHeader(int position) {
-    if (getFirstHeaderPosition() == position) {
-      return true;
-    }
-
-    if (mAdapter.getHeaderId(position) < 0 || indexOutOfBounds(position)) {
+    if (indexOutOfBounds(position)) {
       return false;
     }
 
-    return mAdapter.getHeaderId(position) != mAdapter.getHeaderId(position - 1);
+    long headerId = mAdapter.getHeaderId(position);
+
+    if (headerId < 0) {
+      return false;
+    }
+
+    return position == 0 || headerId != mAdapter.getHeaderId(position - 1);
   }
 
   private boolean indexOutOfBounds(int position) {
     return position < 0 || position >= mAdapter.getItemCount();
-  }
-
-  private int getFirstHeaderPosition() {
-    for (int i = 0; i < mAdapter.getItemCount(); i++) {
-      if (mAdapter.getHeaderId(i) >= 0) {
-        return i;
-      }
-    }
-    return -1;
   }
 
   public Rect getHeaderBounds(RecyclerView recyclerView, View header, View firstView, boolean firstHeader) {


### PR DESCRIPTION
- `indexOutOfBounds()` first to prevent an unnecessary call to `getHeaderId()`
- `getFirstHeaderPosition()`  goes through every item until it finds a header id `>= 0`. By adding the check for `position == 0` (after checking if the headerId is `>= 0`) we can remove the call to `getFirstHeaderPosition()` preventing potentially lots of `getHeaderId()`.