### PR TITLE
Ignore views that don't belong to the adapter

### DIFF
--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/HeaderPositionCalculator.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/HeaderPositionCalculator.java
@@ -90,6 +90,9 @@ public class HeaderPositionCalculator {
   private boolean isStickyHeaderBeingPushedOffscreen(RecyclerView recyclerView, View stickyHeader) {
     View viewAfterHeader = getFirstViewUnobscuredByHeader(recyclerView, stickyHeader);
     int firstViewUnderHeaderPosition = recyclerView.getChildAdapterPosition(viewAfterHeader);
+    if (firstViewUnderHeaderPosition == RecyclerView.NO_POSITION) {
+        return false;
+    }
 
     if (firstViewUnderHeaderPosition > 0 && hasNewHeader(firstViewUnderHeaderPosition)) {
       View nextHeader = mHeaderProvider.getHeader(recyclerView, firstViewUnderHeaderPosition);
@@ -163,7 +166,8 @@ public class HeaderPositionCalculator {
     RecyclerView.LayoutParams layoutParams = (RecyclerView.LayoutParams) item.getLayoutParams();
     Rect headerMargins = mDimensionCalculator.getMargins(header);
 
-    if (mHeaderProvider.getHeader(parent, parent.getChildAdapterPosition(item)) != header) {
+    int adapterPosition = parent.getChildAdapterPosition(item);
+    if (adapterPosition == RecyclerView.NO_POSITION || mHeaderProvider.getHeader(parent, adapterPosition) != header) {
       // Resolves https://github.com/timehop/sticky-headers-recyclerview/issues/36
       // Handles an edge case where a trailing header is smaller than the current sticky header.
       return false;

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/HeaderPositionCalculator.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/HeaderPositionCalculator.java
@@ -59,7 +59,7 @@ public class HeaderPositionCalculator {
 
     if (firstHeader && isStickyHeaderBeingPushedOffscreen(recyclerView, header)) {
       View viewAfterNextHeader = getFirstViewUnobscuredByHeader(recyclerView, header);
-      int firstViewUnderHeaderPosition = recyclerView.getChildPosition(viewAfterNextHeader);
+      int firstViewUnderHeaderPosition = recyclerView.getChildAdapterPosition(viewAfterNextHeader);
       View secondHeader = mHeaderProvider.getHeader(recyclerView, firstViewUnderHeaderPosition);
       translateHeaderWithNextHeader(recyclerView, mOrientationProvider.getOrientation(recyclerView), bounds,
           header, viewAfterNextHeader, secondHeader);
@@ -89,7 +89,7 @@ public class HeaderPositionCalculator {
 
   private boolean isStickyHeaderBeingPushedOffscreen(RecyclerView recyclerView, View stickyHeader) {
     View viewAfterHeader = getFirstViewUnobscuredByHeader(recyclerView, stickyHeader);
-    int firstViewUnderHeaderPosition = recyclerView.getChildPosition(viewAfterHeader);
+    int firstViewUnderHeaderPosition = recyclerView.getChildAdapterPosition(viewAfterHeader);
 
     if (firstViewUnderHeaderPosition > 0 && hasNewHeader(firstViewUnderHeaderPosition)) {
       View nextHeader = mHeaderProvider.getHeader(recyclerView, firstViewUnderHeaderPosition);
@@ -163,7 +163,7 @@ public class HeaderPositionCalculator {
     RecyclerView.LayoutParams layoutParams = (RecyclerView.LayoutParams) item.getLayoutParams();
     Rect headerMargins = mDimensionCalculator.getMargins(header);
 
-    if (mHeaderProvider.getHeader(parent, parent.getChildPosition(item)) != header) {
+    if (mHeaderProvider.getHeader(parent, parent.getChildAdapterPosition(item)) != header) {
       // Resolves https://github.com/timehop/sticky-headers-recyclerview/issues/36
       // Handles an edge case where a trailing header is smaller than the current sticky header.
       return false;

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersDecoration.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersDecoration.java
@@ -57,6 +57,9 @@ public class StickyRecyclerHeadersDecoration extends RecyclerView.ItemDecoration
   public void getItemOffsets(Rect outRect, View view, RecyclerView parent, RecyclerView.State state) {
     super.getItemOffsets(outRect, view, parent, state);
     int itemPosition = parent.getChildAdapterPosition(view);
+    if (itemPosition == RecyclerView.NO_POSITION) {
+        return;
+    }
     if (mHeaderPositionCalculator.hasNewHeader(itemPosition)) {
       View header = getHeaderView(parent, itemPosition);
       setItemOffsetsForHeader(outRect, header, mOrientationProvider.getOrientation(parent));
@@ -91,6 +94,9 @@ public class StickyRecyclerHeadersDecoration extends RecyclerView.ItemDecoration
     for (int i = 0; i < parent.getChildCount(); i++) {
       View itemView = parent.getChildAt(i);
       int position = parent.getChildAdapterPosition(itemView);
+      if (position == RecyclerView.NO_POSITION) {
+          continue;
+      }
       if (hasStickyHeader(i, position) || mHeaderPositionCalculator.hasNewHeader(position)) {
         View header = mHeaderProvider.getHeader(parent, position);
         Rect headerOffset = mHeaderPositionCalculator.getHeaderBounds(parent, header,

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersDecoration.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersDecoration.java
@@ -56,7 +56,7 @@ public class StickyRecyclerHeadersDecoration extends RecyclerView.ItemDecoration
   @Override
   public void getItemOffsets(Rect outRect, View view, RecyclerView parent, RecyclerView.State state) {
     super.getItemOffsets(outRect, view, parent, state);
-    int itemPosition = parent.getChildPosition(view);
+    int itemPosition = parent.getChildAdapterPosition(view);
     if (mHeaderPositionCalculator.hasNewHeader(itemPosition)) {
       View header = getHeaderView(parent, itemPosition);
       setItemOffsetsForHeader(outRect, header, mOrientationProvider.getOrientation(parent));
@@ -90,7 +90,7 @@ public class StickyRecyclerHeadersDecoration extends RecyclerView.ItemDecoration
 
     for (int i = 0; i < parent.getChildCount(); i++) {
       View itemView = parent.getChildAt(i);
-      int position = parent.getChildPosition(itemView);
+      int position = parent.getChildAdapterPosition(itemView);
       if (hasStickyHeader(i, position) || mHeaderPositionCalculator.hasNewHeader(position)) {
         View header = mHeaderProvider.getHeader(parent, position);
         Rect headerOffset = mHeaderPositionCalculator.getHeaderBounds(parent, header,

--- a/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/RecyclerItemClickListener.java
+++ b/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/RecyclerItemClickListener.java
@@ -27,7 +27,7 @@ public class RecyclerItemClickListener implements RecyclerView.OnItemTouchListen
   @Override public boolean onInterceptTouchEvent(RecyclerView view, MotionEvent e) {
     View childView = view.findChildViewUnder(e.getX(), e.getY());
     if (childView != null && mListener != null && mGestureDetector.onTouchEvent(e)) {
-      mListener.onItemClick(childView, view.getChildPosition(childView));
+      mListener.onItemClick(childView, view.getChildAdapterPosition(childView));
     }
     return false;
   }


### PR DESCRIPTION
Thanks for publishing this, it's really helpful!

I'm not sure if it's my particular setup or not, but I'm encountering a crash when I try to use the library. I've narrowed it down to the fact that my `RecyclerView` often has child views that no longer belong to the adapter. I show/hide a progress bar view so I think it has something to do with that.

The crash occurs whenever the library gets a reference to a child of the `RecyclerView`, tries to find the adapter position of it, and then then asks the adapter for the item. My fix is to check for `RecyclerView.NO_POSITION` before using the value.