### PR TITLE
use layoutmanager to determine first visible item.  ViewGroup.getChildAt...

### DIFF
--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersDecoration.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersDecoration.java
@@ -88,25 +88,23 @@ public class StickyRecyclerHeadersDecoration extends RecyclerView.ItemDecoration
       return;
     }
 
-    for (int i = 0; i < parent.getChildCount(); i++) {
-      View itemView = parent.getChildAt(i);
-      int position = parent.getChildPosition(itemView);
-      if (hasStickyHeader(i, position) || mHeaderPositionCalculator.hasNewHeader(position)) {
-        View header = mHeaderProvider.getHeader(parent, position);
-        Rect headerOffset = mHeaderPositionCalculator.getHeaderBounds(parent, header,
-            itemView, hasStickyHeader(i, position));
-        mRenderer.drawHeader(parent, canvas, header, headerOffset);
-        mHeaderRects.put(position, headerOffset);
+    RecyclerView.LayoutManager layoutManager = parent.getLayoutManager();
+    if ( layoutManager instanceof LinearLayoutManager ) {
+      LinearLayoutManager linearLayoutManager = (LinearLayoutManager)layoutManager;
+      int first = linearLayoutManager.findFirstVisibleItemPosition();
+      int last = linearLayoutManager.findLastVisibleItemPosition();
+      for ( int i = first; i <= last; i++ ) {
+        boolean hasStickyHeader = ( i == first && mAdapter.getHeaderId( first ) >= 0 );
+        View itemView = linearLayoutManager.findViewByPosition( i );
+        if ( hasStickyHeader || mHeaderPositionCalculator.hasNewHeader( i ) ) {
+          View header = mHeaderProvider.getHeader(parent, i);
+          Rect headerOffset = mHeaderPositionCalculator.getHeaderBounds(parent, header,
+                  itemView, hasStickyHeader);
+          mRenderer.drawHeader(parent, canvas, header, headerOffset);
+          mHeaderRects.put(i, headerOffset);
+        }
       }
     }
-  }
-
-  private boolean hasStickyHeader(int listChildPosition, int indexInList) {
-    if (listChildPosition > 0 || mAdapter.getHeaderId(indexInList) < 0) {
-      return false;
-    }
-
-    return true;
   }
 
   /**

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersDecoration.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersDecoration.java
@@ -88,21 +88,18 @@ public class StickyRecyclerHeadersDecoration extends RecyclerView.ItemDecoration
       return;
     }
 
-    RecyclerView.LayoutManager layoutManager = parent.getLayoutManager();
-    if ( layoutManager instanceof LinearLayoutManager ) {
-      LinearLayoutManager linearLayoutManager = (LinearLayoutManager)layoutManager;
-      int first = linearLayoutManager.findFirstVisibleItemPosition();
-      int last = linearLayoutManager.findLastVisibleItemPosition();
-      for ( int i = first; i <= last; i++ ) {
-        boolean hasStickyHeader = ( i == first && mAdapter.getHeaderId( first ) >= 0 );
-        View itemView = linearLayoutManager.findViewByPosition( i );
-        if ( hasStickyHeader || mHeaderPositionCalculator.hasNewHeader( i ) ) {
-          View header = mHeaderProvider.getHeader(parent, i);
-          Rect headerOffset = mHeaderPositionCalculator.getHeaderBounds(parent, header,
-                  itemView, hasStickyHeader);
-          mRenderer.drawHeader(parent, canvas, header, headerOffset);
-          mHeaderRects.put(i, headerOffset);
-        }
+    LinearLayoutManager linearLayoutManager = (LinearLayoutManager)parent.getLayoutManager();
+    int first = linearLayoutManager.findFirstVisibleItemPosition();
+    int last = linearLayoutManager.findLastVisibleItemPosition();
+    for (int i = first; i <= last; i++) {
+      boolean hasStickyHeader = (i == first && mAdapter.getHeaderId(i) >= 0);
+      View itemView = linearLayoutManager.findViewByPosition(i);
+      if (hasStickyHeader || mHeaderPositionCalculator.hasNewHeader(i)) {
+        View header = mHeaderProvider.getHeader(parent, i);
+        Rect headerOffset = mHeaderPositionCalculator.getHeaderBounds(parent, header,
+            itemView, hasStickyHeader);
+        mRenderer.drawHeader(parent, canvas, header, headerOffset);
+        mHeaderRects.put(i, headerOffset);
       }
     }
   }


### PR DESCRIPTION
...(0) cannot reliably be used to determine this

This fixes a bug where if you notifyItemChanged on an item in the list it will temporarily show a new header since it is initially childAt(0)