### PR TITLE
Recycleheader

### DIFF
--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/HeaderPositionCalculator.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/HeaderPositionCalculator.java
@@ -3,9 +3,7 @@ package com.timehop.stickyheadersrecyclerview;
 import android.graphics.Rect;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.View;
-import android.widget.TextView;
 
 import com.timehop.stickyheadersrecyclerview.caching.HeaderProvider;
 import com.timehop.stickyheadersrecyclerview.calculation.DimensionCalculator;

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersDecoration.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersDecoration.java
@@ -4,8 +4,10 @@ import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.util.SparseArray;
 import android.view.View;
+import android.widget.TextView;
 
 import com.timehop.stickyheadersrecyclerview.caching.HeaderProvider;
 import com.timehop.stickyheadersrecyclerview.caching.HeaderViewCache;
@@ -15,7 +17,6 @@ import com.timehop.stickyheadersrecyclerview.util.LinearLayoutOrientationProvide
 import com.timehop.stickyheadersrecyclerview.util.OrientationProvider;
 
 public class StickyRecyclerHeadersDecoration extends RecyclerView.ItemDecoration {
-
   private final StickyRecyclerHeadersAdapter mAdapter;
   private final SparseArray<Rect> mHeaderRects = new SparseArray<>();
   private final HeaderProvider mHeaderProvider;
@@ -97,10 +98,12 @@ public class StickyRecyclerHeadersDecoration extends RecyclerView.ItemDecoration
       if (position == RecyclerView.NO_POSITION) {
           continue;
       }
-      if (hasStickyHeader(i, position) || mHeaderPositionCalculator.hasNewHeader(position)) {
+      boolean hasNewHeader = mHeaderPositionCalculator.hasNewHeader(position);
+      boolean hasStickyHeader = hasStickyHeader(i, position);
+      if (hasNewHeader || hasStickyHeader) {
         View header = mHeaderProvider.getHeader(parent, position);
         Rect headerOffset = mHeaderPositionCalculator.getHeaderBounds(parent, header,
-            itemView, hasStickyHeader(i, position));
+                itemView, hasStickyHeader);
         mRenderer.drawHeader(parent, canvas, header, headerOffset);
         mHeaderRects.put(position, headerOffset);
       }

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersDecoration.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersDecoration.java
@@ -4,10 +4,8 @@ import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.util.SparseArray;
 import android.view.View;
-import android.widget.TextView;
 
 import com.timehop.stickyheadersrecyclerview.caching.HeaderProvider;
 import com.timehop.stickyheadersrecyclerview.caching.HeaderViewCache;

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/caching/HeaderViewCache.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/caching/HeaderViewCache.java
@@ -1,25 +1,26 @@
 package com.timehop.stickyheadersrecyclerview.caching;
 
-import android.content.Context;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
-
 import com.timehop.stickyheadersrecyclerview.StickyRecyclerHeadersAdapter;
 import com.timehop.stickyheadersrecyclerview.util.OrientationProvider;
 
 /**
- * An implementation of {@link HeaderProvider} that creates and caches header views
+ * An implementation of {@link HeaderProvider} that creates one header view managed by a
+ * {@link android.support.v7.widget.RecyclerView.ViewHolder}. Each call to
+ * {@link HeaderViewCache#getHeader(RecyclerView, int)}  updates the header to the specified
+ * position with
+ * {@link StickyRecyclerHeadersAdapter#onBindHeaderViewHolder(RecyclerView.ViewHolder, int)}.
+ *
+ * If a ViewHolder/View does not exist, it will be created, measured, and inflated.
  */
 public class HeaderViewCache implements HeaderProvider {
 
   private final StickyRecyclerHeadersAdapter mAdapter;
   private RecyclerView.ViewHolder mViewHolder;
   private final OrientationProvider mOrientationProvider;
-
-  private static final String TAG = HeaderViewCache.class.getSimpleName();
 
   public HeaderViewCache(StickyRecyclerHeadersAdapter adapter,
       OrientationProvider orientationProvider) {
@@ -29,12 +30,11 @@ public class HeaderViewCache implements HeaderProvider {
 
   @Override
   public View getHeader(RecyclerView parent, int position) {
-
     if (mViewHolder == null) {
+      // Create the ViewHolder if it doesn't exist and bind values to it
       mViewHolder = mAdapter.onCreateHeaderViewHolder(parent);
       mAdapter.onBindHeaderViewHolder(mViewHolder, position);
       View header = mViewHolder.itemView;
-      Log.i(TAG, "viewHeader null: itemView " + header.toString());
 
       if (header.getLayoutParams() == null) {
         header.setLayoutParams(new ViewGroup.LayoutParams(
@@ -59,8 +59,7 @@ public class HeaderViewCache implements HeaderProvider {
       header.measure(childWidth, childHeight);
       header.layout(0, 0, header.getMeasuredWidth(), header.getMeasuredHeight());
     } else {
-//      Log.i(TAG, "onBind requested: itemView " + mViewHolder.itemView);
-      mAdapter.onBindHeaderViewHolder(mViewHolder, position);
+        mAdapter.onBindHeaderViewHolder(mViewHolder, position);
     }
 
     return mViewHolder.itemView;
@@ -68,6 +67,5 @@ public class HeaderViewCache implements HeaderProvider {
 
   @Override
   public void invalidate() {
-//    mHeaderViews.clear();
   }
 }

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/caching/HeaderViewCache.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/caching/HeaderViewCache.java
@@ -1,8 +1,9 @@
 package com.timehop.stickyheadersrecyclerview.caching;
 
-import android.support.v4.util.LongSparseArray;
+import android.content.Context;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -15,8 +16,10 @@ import com.timehop.stickyheadersrecyclerview.util.OrientationProvider;
 public class HeaderViewCache implements HeaderProvider {
 
   private final StickyRecyclerHeadersAdapter mAdapter;
-  private final LongSparseArray<View> mHeaderViews = new LongSparseArray<>();
+  private RecyclerView.ViewHolder mViewHolder;
   private final OrientationProvider mOrientationProvider;
+
+  private static final String TAG = HeaderViewCache.class.getSimpleName();
 
   public HeaderViewCache(StickyRecyclerHeadersAdapter adapter,
       OrientationProvider orientationProvider) {
@@ -26,14 +29,13 @@ public class HeaderViewCache implements HeaderProvider {
 
   @Override
   public View getHeader(RecyclerView parent, int position) {
-    long headerId = mAdapter.getHeaderId(position);
 
-    View header = mHeaderViews.get(headerId);
-    if (header == null) {
-      //TODO - recycle views
-      RecyclerView.ViewHolder viewHolder = mAdapter.onCreateHeaderViewHolder(parent);
-      mAdapter.onBindHeaderViewHolder(viewHolder, position);
-      header = viewHolder.itemView;
+    if (mViewHolder == null) {
+      mViewHolder = mAdapter.onCreateHeaderViewHolder(parent);
+      mAdapter.onBindHeaderViewHolder(mViewHolder, position);
+      View header = mViewHolder.itemView;
+      Log.i(TAG, "viewHeader null: itemView " + header.toString());
+
       if (header.getLayoutParams() == null) {
         header.setLayoutParams(new ViewGroup.LayoutParams(
             ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT));
@@ -56,13 +58,16 @@ public class HeaderViewCache implements HeaderProvider {
           parent.getPaddingTop() + parent.getPaddingBottom(), header.getLayoutParams().height);
       header.measure(childWidth, childHeight);
       header.layout(0, 0, header.getMeasuredWidth(), header.getMeasuredHeight());
-      mHeaderViews.put(headerId, header);
+    } else {
+//      Log.i(TAG, "onBind requested: itemView " + mViewHolder.itemView);
+      mAdapter.onBindHeaderViewHolder(mViewHolder, position);
     }
-    return header;
+
+    return mViewHolder.itemView;
   }
 
   @Override
   public void invalidate() {
-    mHeaderViews.clear();
+//    mHeaderViews.clear();
   }
 }

--- a/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/MainActivity.java
+++ b/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/MainActivity.java
@@ -6,7 +6,6 @@ import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -21,7 +20,6 @@ import java.security.SecureRandom;
 import java.util.HashMap;
 
 public class MainActivity extends Activity {
-  public static final String TAG = MainActivity.class.getSimpleName();
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {

--- a/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/MainActivity.java
+++ b/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/MainActivity.java
@@ -100,14 +100,13 @@ public class MainActivity extends Activity {
 
     @Override
     public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
-//      Log.i(TAG, "onBindViewHolder: position: " + position);
       TextView textView = (TextView) holder.itemView;
       textView.setText(getItem(position));
     }
 
     @Override
     public long getHeaderId(int position) {
-//      Log.i(TAG, "getHeaderId: " + position);
+      // Don't count first row when drawing headers; it's set to "Animals below!"
       if (position == 0) {
         return -1;
       } else {
@@ -123,16 +122,15 @@ public class MainActivity extends Activity {
       };
     }
 
+    // TODO: consider changing onBindHeaderViewHolder interface to take headerId instead of position to match the consistency with onBindViewHolder
     @Override
     public void onBindHeaderViewHolder(RecyclerView.ViewHolder holder, int position) {
-//      Log.i(TAG, "MA/onBindHeaderViewHolder headerId: " + getHeaderId(position));
-//      Log.i(TAG, "MA getItem: " + getItem(position));
       TextView textView = (TextView) holder.itemView;
-      textView.setText(String.valueOf(getItem(position).charAt(0)));
+      textView.setText(getItem(position));
 
       // Get the color mapped to the header Id
       long headerId = getHeaderId(position);
-      Integer backgroundColor = mBackgroundColorMap.get(getHeaderId(position));
+      Integer backgroundColor = mBackgroundColorMap.get(headerId);
 
       if (backgroundColor == null) {
         backgroundColor = getRandomColor();
@@ -140,7 +138,6 @@ public class MainActivity extends Activity {
       }
 
       textView.setBackgroundColor(backgroundColor);
-//      holder.itemView.setBackgroundColor(getRandomColor());
     }
 
     private int getRandomColor() {

--- a/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/MainActivity.java
+++ b/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/MainActivity.java
@@ -6,6 +6,7 @@ import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -17,8 +18,10 @@ import com.timehop.stickyheadersrecyclerview.StickyRecyclerHeadersDecoration;
 import com.timehop.stickyheadersrecyclerview.StickyRecyclerHeadersTouchListener;
 
 import java.security.SecureRandom;
+import java.util.HashMap;
 
 public class MainActivity extends Activity {
+  public static final String TAG = MainActivity.class.getSimpleName();
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -84,6 +87,9 @@ public class MainActivity extends Activity {
 
   private class SampleArrayHeadersAdapter extends RecyclerArrayAdapter<String, RecyclerView.ViewHolder>
       implements StickyRecyclerHeadersAdapter<RecyclerView.ViewHolder> {
+
+    HashMap<Long, Integer> mBackgroundColorMap = new HashMap<>();
+
     @Override
     public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
       View view = LayoutInflater.from(parent.getContext())
@@ -94,12 +100,14 @@ public class MainActivity extends Activity {
 
     @Override
     public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
+//      Log.i(TAG, "onBindViewHolder: position: " + position);
       TextView textView = (TextView) holder.itemView;
       textView.setText(getItem(position));
     }
 
     @Override
     public long getHeaderId(int position) {
+//      Log.i(TAG, "getHeaderId: " + position);
       if (position == 0) {
         return -1;
       } else {
@@ -117,9 +125,22 @@ public class MainActivity extends Activity {
 
     @Override
     public void onBindHeaderViewHolder(RecyclerView.ViewHolder holder, int position) {
+//      Log.i(TAG, "MA/onBindHeaderViewHolder headerId: " + getHeaderId(position));
+//      Log.i(TAG, "MA getItem: " + getItem(position));
       TextView textView = (TextView) holder.itemView;
       textView.setText(String.valueOf(getItem(position).charAt(0)));
-      holder.itemView.setBackgroundColor(getRandomColor());
+
+      // Get the color mapped to the header Id
+      long headerId = getHeaderId(position);
+      Integer backgroundColor = mBackgroundColorMap.get(getHeaderId(position));
+
+      if (backgroundColor == null) {
+        backgroundColor = getRandomColor();
+        mBackgroundColorMap.put(headerId, backgroundColor);
+      }
+
+      textView.setBackgroundColor(backgroundColor);
+//      holder.itemView.setBackgroundColor(getRandomColor());
     }
 
     private int getRandomColor() {


### PR DESCRIPTION
`HeaderViewCache` now recycles the header View using the view holder pattern - `getHeader` calls the adapter's `onBindHeaderViewHolder` and updates the single header View and returns it. 

In the previous implementation, if you wanted to update the header based on each item in the list (say, a different thumbnail image ID based on header ID), you would make and hold a reference to a new View in a SparseArray for each one, taking up O(n) space. Now, only one View exists for the header and calls `onBindHeaderViewHolder` to replace values in the header and return it. `MainActivity` was modified to show this off and use the entire String of the last obscured row item as the header instead of just the first letter.

ISSUES: 
- With one View allowed, that View is specified and inflated in the adapter's `onCreateHeaderViewHolder` and once the ViewHolder is made, the header size is fixed. I can't think of many use cases where you would want a header that dynamically changes in size though.

- `HeaderPositionCalculator` can't call `getHeader` without refrain - the order in which `getHeader` is called matters a lot now because it binds the header to the matching value in `position`. Those excess `getHeader` calls aren't really necessary now anyway; with only one header View allowed, the `secondHeader` and `nextHeader` parameters will always reference the same header as `firstHeader`.

- `MainActivity#SampleArrayHeadersAdapter` has to keep track of all the background colors and cannot call `getRandomCall` every time the header is bound. Binding happens a lot, and it would create a new color for every bind. This is on par with how one would make their adapter for their data set anyway; another list of header values to be bound as defined in `onBindHeaderViewHolder`.