### PR TITLE
For SDK 10, smaller clip area for headers

### DIFF
--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/rendering/HeaderRenderer.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/rendering/HeaderRenderer.java
@@ -51,7 +51,7 @@ public class HeaderRenderer {
     canvas.restore();
   }
 
-  /**
+   /**
    * Gets a clipping rect for the header based on the margins of the header and the padding of the
    * recycler.
    * FIXME: Currently right margin in VERTICAL orientation and bottom margin in HORIZONTAL
@@ -60,22 +60,80 @@ public class HeaderRenderer {
    *
    * @param recyclerView for which to provide a header
    * @param header       for clipping
+   * @param offset       for clipping specific view offset rather than entire recyclerview
    * @return a {@link Rect} for clipping a provided header to the padding of a recycler view
    */
-  private Rect getClipRectForHeader(RecyclerView recyclerView, View header) {
+  private Rect getClipRectForHeader(RecyclerView recyclerView, View header, Rect offset) {
     Rect headerMargins = mDimensionCalculator.getMargins(header);
     if (mOrientationProvider.getOrientation(recyclerView) == LinearLayout.VERTICAL) {
-      return new Rect(
-          recyclerView.getPaddingLeft(),
-          recyclerView.getPaddingTop(),
-          recyclerView.getWidth() - recyclerView.getPaddingRight() - headerMargins.right,
-          recyclerView.getHeight() - recyclerView.getPaddingBottom());
+
+      int offsetBottom = offset.top + header.getHeight();
+      int recyclerBottom = recyclerView.getHeight() - recyclerView.getPaddingBottom();
+
+      // If offsets are above or below no need for visibility
+      if (offset.top <= recyclerView.getPaddingTop() && offsetBottom <= recyclerView.getPaddingTop()
+              || offsetBottom >= recyclerBottom && offset.top >= recyclerBottom) {
+          return new Rect(0, 0, 0, 0);
+
+      // If topOffset within top padding and bottomOffset NOT within top padding
+      } else if (offset.top < recyclerView.getPaddingTop() && offsetBottom > recyclerView.getPaddingTop()) {
+              return new Rect(
+                      recyclerView.getPaddingLeft(),
+                      recyclerView.getPaddingTop(),
+                      recyclerView.getWidth() - recyclerView.getPaddingRight() - headerMargins.right,
+                      offsetBottom);
+
+      // If offsetBottom within bottom padding and offsetTop NOT within bottom padding
+      } else if (offsetBottom > recyclerBottom && offset.top < recyclerBottom) {
+          return new Rect(
+                  recyclerView.getPaddingLeft(),
+                  offset.top,
+                  recyclerView.getWidth() - recyclerView.getPaddingRight() - headerMargins.right,
+                  recyclerBottom);
+
+      // Else use offset for all clips
+      } else {
+          return new Rect(
+                  recyclerView.getPaddingLeft(),
+                  offset.top,
+                  recyclerView.getWidth() - recyclerView.getPaddingRight() - headerMargins.right,
+                  offset.top + header.getHeight());
+      }
     } else {
-      return new Rect(
-          recyclerView.getPaddingLeft(),
-          recyclerView.getPaddingTop(),
-          recyclerView.getWidth() - recyclerView.getPaddingRight(),
-          recyclerView.getHeight() - recyclerView.getPaddingBottom() - headerMargins.bottom);
+
+      int offsetRight = offset.left + header.getWidth();
+      int recyclerRight = recyclerView.getWidth() - recyclerView.getPaddingRight();
+      
+       // If offsets are both to right or left, no need for visibility
+      if (offset.left <= recyclerView.getPaddingLeft() && offsetRight <= recyclerView.getPaddingLeft()
+              || offsetRight >= recyclerRight && offset.left >= recyclerRight) {
+          return new Rect(0, 0, 0, 0);
+
+      // If offsetLeft within paddingLeft and offsetRight NOT within paddingLeft
+      } else if (offset.left < recyclerView.getPaddingLeft() && offsetRight > recyclerView.getPaddingLeft()) {
+          return new Rect(
+                  recyclerView.getPaddingLeft(),
+                  recyclerView.getPaddingTop(),
+                  offsetRight,
+                  recyclerView.getHeight() - recyclerView.getPaddingBottom() - headerMargins.bottom);
+
+      // If offsetRight within paddingRight and offsetLeft NOT within paddingRight
+      } else if (offsetRight > recyclerRight && offset.left < recyclerRight) {
+          return new Rect(
+                  offset.left,
+                  recyclerView.getPaddingTop(),
+                  recyclerView.getWidth() - recyclerView.getPaddingRight(),
+                  recyclerView.getHeight() - recyclerView.getPaddingBottom()- headerMargins.bottom);
+
+      // Else use offset for all clips
+      } else {
+          return new Rect(
+                  offset.left,
+                  recyclerView.getPaddingTop(),
+                  offsetRight,
+                  recyclerView.getHeight() - recyclerView.getPaddingBottom() - headerMargins.bottom);
+      }
+
     }
   }
 


### PR DESCRIPTION
For #25

One largely noticeable issue with Gingerbread was that the clipRect for the header decorations was not clipping properly (not sure the exact reason), but by specifying the clip area to the actual area for the header when it is in view and clipping to the padding of the recycler view when not in view seems to have resolved this. 

Not entirely sure if this has other repercussions at this point and this is a somewhat quick and dirty solution, but I tested the sample app on 2.3.7 and 5.1.1 and did not see any issues. Still testing to see if there are any other issues with sdk 10.

Lemme know if you have any feedback or things you want me to test before merging!