### PR TITLE
Don't propagate touch to items behind a header (update StickyRecyclerHeadersTouchListener)

### DIFF
--- a/sample/src/main/res/drawable/white_touch.xml
+++ b/sample/src/main/res/drawable/white_touch.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/holo_blue_light" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/white" />
+        </shape>
+    </item>
+</selector>

--- a/sample/src/main/res/layout/view_item.xml
+++ b/sample/src/main/res/layout/view_item.xml
@@ -4,10 +4,11 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="horizontal"
+    android:clickable="true"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:padding="@dimen/small"
     android:textSize="14sp"
     tools:text="Aardvark"
-    android:background="@android:color/white"
+    android:background="@drawable/white_touch"
     tools:context=".MainActivity"/>


### PR DESCRIPTION
When a sticky header is touched, a regular item behind it may receive the ACTION_DOWN event, and display "pressed" state.  This commit fixes such undesired behavior by returning *true* for `onInterceptTouchEvent()` if it was DOWN inside the borders of a sticky header.