### PR TITLE
Introduce a non sticky header switch

### DIFF
--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/HeaderPositionCalculator.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/HeaderPositionCalculator.java
@@ -19,6 +19,7 @@ public class HeaderPositionCalculator {
   private final OrientationProvider mOrientationProvider;
   private final HeaderProvider mHeaderProvider;
   private final DimensionCalculator mDimensionCalculator;
+  private boolean mSticky = true; // Headers are sticky by default.
 
   public HeaderPositionCalculator(StickyRecyclerHeadersAdapter adapter, HeaderProvider headerProvider,
       OrientationProvider orientationProvider, DimensionCalculator dimensionCalculator) {
@@ -50,6 +51,10 @@ public class HeaderPositionCalculator {
     }
 
     return offset <= margin && mAdapter.getHeaderId(position) >= 0;
+  }
+
+  public void setSticky(boolean sticky) {
+    mSticky = sticky;
   }
 
   /**
@@ -108,12 +113,12 @@ public class HeaderPositionCalculator {
       translationX = firstView.getLeft() + headerMargins.left;
       translationY = Math.max(
           firstView.getTop() - header.getHeight() - headerMargins.bottom,
-          getListTop(recyclerView) + headerMargins.top);
+          mSticky ? getListTop(recyclerView) + headerMargins.top : Integer.MIN_VALUE);
     } else {
       translationY = firstView.getTop() + headerMargins.top;
       translationX = Math.max(
           firstView.getLeft() - header.getWidth() - headerMargins.right,
-          getListLeft(recyclerView) + headerMargins.left);
+          mSticky ? getListLeft(recyclerView) + headerMargins.left : Integer.MIN_VALUE);
     }
 
     return new Rect(translationX, translationY, translationX + header.getWidth(),
@@ -124,7 +129,7 @@ public class HeaderPositionCalculator {
     View viewAfterHeader = getFirstViewUnobscuredByHeader(recyclerView, stickyHeader);
     int firstViewUnderHeaderPosition = recyclerView.getChildAdapterPosition(viewAfterHeader);
     if (firstViewUnderHeaderPosition == RecyclerView.NO_POSITION) {
-        return false;
+      return false;
     }
 
     boolean isReverseLayout = mOrientationProvider.isReverseLayout(recyclerView);
@@ -191,7 +196,6 @@ public class HeaderPositionCalculator {
 
   /**
    * Determines if an item is obscured by a header
-   *
    *
    * @param parent
    * @param item        to determine if obscured by header

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersDecoration.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersDecoration.java
@@ -58,7 +58,7 @@ public class StickyRecyclerHeadersDecoration extends RecyclerView.ItemDecoration
     super.getItemOffsets(outRect, view, parent, state);
     int itemPosition = parent.getChildAdapterPosition(view);
     if (itemPosition == RecyclerView.NO_POSITION) {
-        return;
+      return;
     }
     if (mHeaderPositionCalculator.hasNewHeader(itemPosition, mOrientationProvider.isReverseLayout(parent))) {
       View header = getHeaderView(parent, itemPosition);
@@ -95,7 +95,7 @@ public class StickyRecyclerHeadersDecoration extends RecyclerView.ItemDecoration
       View itemView = parent.getChildAt(i);
       int position = parent.getChildAdapterPosition(itemView);
       if (position == RecyclerView.NO_POSITION) {
-          continue;
+        continue;
       }
 
       boolean hasStickyHeader = mHeaderPositionCalculator.hasStickyHeader(itemView, mOrientationProvider.getOrientation(parent), position);
@@ -143,5 +143,13 @@ public class StickyRecyclerHeadersDecoration extends RecyclerView.ItemDecoration
    */
   public void invalidateHeaders() {
     mHeaderProvider.invalidate();
+  }
+
+  /**
+   * Determines the behavior of the headers. They're sticky by default.
+   * @param sticky set to true if the headers should be sticky, false otherwise.
+   */
+  public void setHeadersSticky(boolean sticky) {
+    mHeaderPositionCalculator.setSticky(sticky);
   }
 }


### PR DESCRIPTION
This introduces the ability to change the header to a non sticky mode without breaking the api.

To be used like this:

```java
    final StickyRecyclerHeadersDecoration headersDecor = new StickyRecyclerHeadersDecoration(mAdapter);
    headersDecor.setHeadersSticky(false);
    recyclerView.addItemDecoration(headersDecor);
```

I would kinda like to introduce a builder pattern and make a creator for `StickyRecyclerHeadersDecoration.java`. This would however break the api.
```java
recyclerView.addItemDecoration(StickyRecyclerHeadersDecoration.with(mAdapter)
                                                              .setHeadersSticky(false);
```