### PR TITLE
Adds an example in which data and header groups are separated

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -17,6 +17,9 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <activity
+            android:name=".AdvancedDatasetActivity">
+        </activity>
     </application>
 
 </manifest>

--- a/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/AdvancedDatasetActivity.java
+++ b/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/AdvancedDatasetActivity.java
@@ -1,0 +1,155 @@
+package com.timehop.stickyheadersrecyclerview.sample;
+
+import android.app.Activity;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import com.timehop.stickyheadersrecyclerview.StickyRecyclerHeadersAdapter;
+import com.timehop.stickyheadersrecyclerview.StickyRecyclerHeadersDecoration;
+import com.timehop.stickyheadersrecyclerview.sample.AnimalsAdapter;
+import com.timehop.stickyheadersrecyclerview.sample.DividerDecoration;
+import com.timehop.stickyheadersrecyclerview.sample.R;
+
+import java.security.SecureRandom;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+
+public class AdvancedDatasetActivity extends Activity {
+    final Map<String, String> mAnimalColors = new HashMap<>();
+    final AnimalsColorHeadersAdapter mAdapter = new AnimalsColorHeadersAdapter();
+
+    final String COLORNAME_BLACK = "Black";
+    final String COLORNAME_BLUE = "Blue";
+    final String COLORNAME_BROWN = "Brown";
+    final String COLORNAME_OTHER = "Other";
+
+    Comparator<String> mColorComparator = new Comparator<String>() {
+        @Override
+        public int compare(String lhsName, String rhsName) {
+            // order by (color, name)
+            String lhsColor = getColorForAnimalName(lhsName);
+            String rhsColor = getColorForAnimalName(rhsName);
+
+            if (lhsColor.compareTo(rhsColor) < 0) {
+                // lhsColor < rhsColor
+                return -1;
+            } else if (lhsColor.compareTo(rhsColor) > 0) {
+                // lhsColor > rhsColor
+                return 1;
+            } else {
+                // color is equal
+                return lhsName.compareTo(rhsName);
+            }
+        }
+    };
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_advanced);
+
+        final RecyclerView recyclerView = (RecyclerView) findViewById(R.id.recyclerview);
+
+        // Add initial data to color map
+        mAnimalColors.put("Aye Aye", COLORNAME_BROWN);
+        mAnimalColors.put("Black Bear", COLORNAME_BLACK);
+        mAnimalColors.put("Black Rhinoceros", COLORNAME_BLACK);
+        mAnimalColors.put("Black Russian Terrier", COLORNAME_BLACK);
+        mAnimalColors.put("Black Widow Spider", COLORNAME_BLACK);
+        mAnimalColors.put("Blue Lacy Dog", COLORNAME_BLUE);
+        mAnimalColors.put("Blue Whale", COLORNAME_BLUE);
+        mAnimalColors.put("Highland Cattle", COLORNAME_BROWN);
+
+        // Populate adapter with example dummy data
+        mAdapter.addAll(getDummyDataSet());
+        mAdapter.sort(mColorComparator);
+        recyclerView.setAdapter(mAdapter);
+
+        // Set layout manager
+        final LinearLayoutManager layoutManager = new LinearLayoutManager(this);
+        recyclerView.setLayoutManager(layoutManager);
+
+        // Add the sticky headers decoration
+        final StickyRecyclerHeadersDecoration headersDecor = new StickyRecyclerHeadersDecoration(mAdapter);
+        recyclerView.addItemDecoration(headersDecor);
+
+        // Add decoration for dividers between list items
+        recyclerView.addItemDecoration(new DividerDecoration(this));
+
+        /*
+        mAdapter.registerAdapterDataObserver(new RecyclerView.AdapterDataObserver() {
+            @Override
+            public void onChanged() {
+                //headersDecor.invalidateHeaders();
+            }
+        });
+        */
+    }
+
+    private String[] getDummyDataSet() {
+        return getResources().getStringArray(R.array.animals);
+    }
+
+    private String getColorForAnimalName(String animalName) {
+        if (mAnimalColors.containsKey(animalName)) {
+            return mAnimalColors.get(animalName);
+        } else {
+            return COLORNAME_OTHER;
+        }
+    }
+
+    public void toggleAyeAyeColorClicked(View v) {
+        if (mAnimalColors.get("Aye Aye").equals(COLORNAME_BROWN)) {
+            mAnimalColors.put("Aye Aye", COLORNAME_BLACK);
+        } else {
+            mAnimalColors.put("Aye Aye", COLORNAME_BROWN);
+        }
+        mAdapter.sort(mColorComparator);
+    }
+
+    private class AnimalsColorHeadersAdapter extends AnimalsAdapter<RecyclerView.ViewHolder>
+            implements StickyRecyclerHeadersAdapter<RecyclerView.ViewHolder> {
+        @Override
+        public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+            View view = LayoutInflater.from(parent.getContext())
+                    .inflate(R.layout.view_item, parent, false);
+            return new RecyclerView.ViewHolder(view) {
+            };
+        }
+
+        @Override
+        public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
+            TextView textView = (TextView) holder.itemView;
+            textView.setText(getItem(position));
+        }
+
+        @Override
+        public long getHeaderId(int position) {
+            String colorName = getColorForAnimalName(getItem(position));
+            return colorName.hashCode();
+        }
+
+        @Override
+        public RecyclerView.ViewHolder onCreateHeaderViewHolder(ViewGroup parent) {
+            View view = LayoutInflater.from(parent.getContext())
+                    .inflate(R.layout.view_header, parent, false);
+            return new RecyclerView.ViewHolder(view) {
+            };
+        }
+
+        @Override
+        public void onBindHeaderViewHolder(RecyclerView.ViewHolder holder, int position) {
+            String colorName = getColorForAnimalName(getItem(position));
+            TextView textView = (TextView) holder.itemView;
+            textView.setText(colorName);
+        }
+    }
+}

--- a/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/AnimalsAdapter.java
+++ b/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/AnimalsAdapter.java
@@ -5,6 +5,8 @@ import android.support.v7.widget.RecyclerView;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 
 
 /**
@@ -46,6 +48,11 @@ public abstract class AnimalsAdapter<VH extends RecyclerView.ViewHolder>
 
   public void remove(String object) {
     items.remove(object);
+    notifyDataSetChanged();
+  }
+
+  public void sort(Comparator<String> comparator) {
+    Collections.sort(items, comparator);
     notifyDataSetChanged();
   }
 

--- a/sample/src/main/res/layout/activity_advanced.xml
+++ b/sample/src/main/res/layout/activity_advanced.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+
+    <LinearLayout
+        android:id="@+id/buttons_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/button_move"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/button_move"
+            android:onClick="toggleAyeAyeColorClicked"
+            />
+
+    </LinearLayout>
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/recyclerview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/buttons_container"
+        android:layout_margin="18dp"
+        android:padding="16dp"
+        android:background="#ffbef0ff"
+        android:saveEnabled="false"
+        android:clipToPadding="true"
+        />
+
+</LinearLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -4,5 +4,6 @@
     <string name="app_name">StickyHeadersRecyclerView</string>
     <string name="button_update">Start Update</string>
     <string name="button_reverse">Is reverse</string>
+    <string name="button_move">Make Aye Aye brown/black</string>
 
 </resources>


### PR DESCRIPTION
During my debugging I needed an example in which the list headers are independent from the items, i.e. one item can be moved between different header groups. The existing example could not easily be extended without removing it's simplicity for basic use cases. Thus I created another Activity that recycles a lot from the existing code. A user can start this activity by right-clicking it from Android studio. At the moment there is no in-app-link.

I was already about to throw this away because the bug was in my backend but I thought there is some value in this. Please feel free to just close this if it does not help.