### PR TITLE
Fixed cache cleaning - clear cached header rects too

### DIFF
--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersDecoration.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersDecoration.java
@@ -154,5 +154,6 @@ public class StickyRecyclerHeadersDecoration extends RecyclerView.ItemDecoration
    */
   public void invalidateHeaders() {
     mHeaderProvider.invalidate();
+    mHeaderRects.clear();
   }
 }


### PR DESCRIPTION
If list with headers is transformed to list without headers, cached rects must be cleared too. Otherwise we can get null pointer exception in some cases.