### PR TITLE
itemIsObscuredByHeader() padding fix

### DIFF
--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/HeaderPositionCalculator.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/HeaderPositionCalculator.java
@@ -228,13 +228,13 @@ public class HeaderPositionCalculator {
 
     if (orientation == LinearLayoutManager.VERTICAL) {
       int itemTop = item.getTop() - layoutParams.topMargin;
-      int headerBottom = header.getBottom() + mTempRect1.bottom + mTempRect1.top;
+      int headerBottom = getListTop(parent) + header.getBottom() + mTempRect1.bottom + mTempRect1.top;
       if (itemTop > headerBottom) {
         return false;
       }
     } else {
       int itemLeft = item.getLeft() - layoutParams.leftMargin;
-      int headerRight = header.getRight() + mTempRect1.right + mTempRect1.left;
+      int headerRight = getListLeft(parent) + header.getRight() + mTempRect1.right + mTempRect1.left;
       if (itemLeft > headerRight) {
         return false;
       }

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/HeaderPositionCalculator.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/HeaderPositionCalculator.java
@@ -229,13 +229,13 @@ public class HeaderPositionCalculator {
     if (orientation == LinearLayoutManager.VERTICAL) {
       int itemTop = item.getTop() - layoutParams.topMargin;
       int headerBottom = getListTop(parent) + header.getBottom() + mTempRect1.bottom + mTempRect1.top;
-      if (itemTop > headerBottom) {
+      if (itemTop >= headerBottom) {
         return false;
       }
     } else {
       int itemLeft = item.getLeft() - layoutParams.leftMargin;
       int headerRight = getListLeft(parent) + header.getRight() + mTempRect1.right + mTempRect1.left;
-      if (itemLeft > headerRight) {
+      if (itemLeft >= headerRight) {
         return false;
       }
     }


### PR DESCRIPTION
While working on [some code to add a shadow to headers](https://github.com/timehop/sticky-headers-recyclerview/issues/85#issuecomment-190409832) I found an issue with the `itemIsObscuredByHeader()` function.  It didn't seem to consider the Recycler's padding like some of the other functions do.