### PR TITLE
Add position param to onCreateHeaderViewHolder

### DIFF
--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersAdapter.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersAdapter.java
@@ -20,9 +20,10 @@ public interface StickyRecyclerHeadersAdapter<VH extends RecyclerView.ViewHolder
    * to inflate the layout for the header.
    *
    * @param parent the view to create a header view holder for
+   * @param position the position of the item to create the view holder for.
    * @return the view holder
    */
-  VH onCreateHeaderViewHolder(ViewGroup parent);
+  VH onCreateHeaderViewHolder(ViewGroup parent, int position);
 
   /**
    * Binds an existing ViewHolder to the specified adapter position.

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/caching/HeaderViewCache.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/caching/HeaderViewCache.java
@@ -31,7 +31,7 @@ public class HeaderViewCache implements HeaderProvider {
     View header = mHeaderViews.get(headerId);
     if (header == null) {
       //TODO - recycle views
-      RecyclerView.ViewHolder viewHolder = mAdapter.onCreateHeaderViewHolder(parent);
+      RecyclerView.ViewHolder viewHolder = mAdapter.onCreateHeaderViewHolder(parent, position);
       mAdapter.onBindHeaderViewHolder(viewHolder, position);
       header = viewHolder.itemView;
       if (header.getLayoutParams() == null) {

--- a/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/MainActivity.java
+++ b/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/MainActivity.java
@@ -142,7 +142,7 @@ public class MainActivity extends AppCompatActivity {
     }
 
     @Override
-    public RecyclerView.ViewHolder onCreateHeaderViewHolder(ViewGroup parent) {
+    public RecyclerView.ViewHolder onCreateHeaderViewHolder(ViewGroup parent, int position) {
       View view = LayoutInflater.from(parent.getContext())
           .inflate(R.layout.view_header, parent, false);
       return new RecyclerView.ViewHolder(view) {


### PR DESCRIPTION
This way, users of the lib may create different view holders according to the item type at the given position (see https://github.com/timehop/sticky-headers-recyclerview/issues/97).
