### PR TITLE
[Feature] 'currentSticky' && OnStickHeaderChanged()

### DIFF
--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/HeaderPositionCalculator.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/HeaderPositionCalculator.java
@@ -37,6 +37,18 @@ public class HeaderPositionCalculator {
   }
 
   /**
+   * Listener for stick-headers' changing events
+   */
+  public interface StickHeaderChangedListerner {
+    void onStickHeaderChanged(View newHeader,View oldHeader);
+
+  }
+  private StickHeaderChangedListerner mListener;
+  public void setHeaderChangedListener(StickHeaderChangedListerner listener) {
+    this.mListener = listener;
+  }
+
+  /**
    * Determines if a view should have a sticky header.
    * The view has a sticky header if:
    * 1. It is the first element in the recycler view
@@ -105,6 +117,12 @@ public class HeaderPositionCalculator {
       translateHeaderWithNextHeader(recyclerView, mOrientationProvider.getOrientation(recyclerView), bounds,
           header, viewAfterNextHeader, secondHeader);
     }
+
+    if(firstHeader && !isStickyHeaderBeingPushedOffscreen(recyclerView,header)){
+      if(null!=mListener){
+        mListener.onStickHeaderChanged(header, null);
+      }
+    }
   }
 
   private void initDefaultHeaderOffset(Rect headerMargins, RecyclerView recyclerView, View header, View firstView, int orientation) {
@@ -153,13 +171,29 @@ public class HeaderPositionCalculator {
         int topOfNextHeader = viewAfterHeader.getTop() - mTempRect1.bottom - nextHeader.getHeight() - mTempRect1.top;
         int bottomOfThisHeader = recyclerView.getPaddingTop() + stickyHeader.getBottom() + mTempRect2.top + mTempRect2.bottom;
         if (topOfNextHeader < bottomOfThisHeader) {
+          if (null != mListener) {
+            mListener.onStickHeaderChanged(nextHeader, stickyHeader);
+          }
+
           return true;
+        }else{
+          if (null != mListener) {
+            mListener.onStickHeaderChanged(stickyHeader, nextHeader);
+          }
         }
       } else {
         int leftOfNextHeader = viewAfterHeader.getLeft() - mTempRect1.right - nextHeader.getWidth() - mTempRect1.left;
         int rightOfThisHeader = recyclerView.getPaddingLeft() + stickyHeader.getRight() + mTempRect2.left + mTempRect2.right;
         if (leftOfNextHeader < rightOfThisHeader) {
+          if (null != mListener) {
+            mListener.onStickHeaderChanged(nextHeader, stickyHeader);
+          }
+
           return true;
+        }else{
+          if (null != mListener) {
+            mListener.onStickHeaderChanged(stickyHeader, nextHeader);
+          }
         }
       }
     }

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersDecoration.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersDecoration.java
@@ -65,6 +65,18 @@ public class StickyRecyclerHeadersDecoration extends RecyclerView.ItemDecoration
     mVisibilityAdapter = visibilityAdapter;
   }
 
+  /**
+   * set listener for stick-headers' changed events
+   *
+   * @param listener
+     */
+  public void setOnStickHeaderChangedListener(
+          HeaderPositionCalculator.StickHeaderChangedListerner listener) {
+    if (null != mHeaderPositionCalculator) {
+      mHeaderPositionCalculator.setHeaderChangedListener(listener);
+    }
+  }
+
   @Override
   public void getItemOffsets(Rect outRect, View view, RecyclerView parent, RecyclerView.State state) {
     super.getItemOffsets(outRect, view, parent, state);

--- a/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersTouchListener.java
+++ b/library/src/main/java/com/timehop/stickyheadersrecyclerview/StickyRecyclerHeadersTouchListener.java
@@ -13,7 +13,7 @@ public class StickyRecyclerHeadersTouchListener implements RecyclerView.OnItemTo
   private OnHeaderClickListener mOnHeaderClickListener;
 
   public interface OnHeaderClickListener {
-    void onHeaderClick(View header, int position, long headerId);
+    void onHeaderClick(View header, int position, long headerId, boolean currentSticky);
   }
 
   public StickyRecyclerHeadersTouchListener(final RecyclerView recyclerView,
@@ -68,7 +68,19 @@ public class StickyRecyclerHeadersTouchListener implements RecyclerView.OnItemTo
       if (position != -1) {
         View headerView = mDecor.getHeaderView(mRecyclerView, position);
         long headerId = getAdapter().getHeaderId(position);
-        mOnHeaderClickListener.onHeaderClick(headerView, position, headerId);
+
+        float recylerX = mRecyclerView.getX();
+        float recylerY = mRecyclerView.getY();
+
+        float headerWidth = headerView.getWidth();
+        float headerHeight = headerView.getHeight();
+
+        boolean sticky = false;
+        if (e.getX() - recylerX <= headerWidth && e.getY() - recylerY < headerHeight) {
+          sticky = true;
+        }
+
+        mOnHeaderClickListener.onHeaderClick(headerView, position, headerId, sticky);
         mRecyclerView.playSoundEffect(SoundEffectConstants.CLICK);
         headerView.onTouchEvent(e);
         return true;

--- a/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/MainActivity.java
+++ b/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/MainActivity.java
@@ -16,6 +16,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 import android.widget.ToggleButton;
 
+import com.timehop.stickyheadersrecyclerview.HeaderPositionCalculator;
 import com.timehop.stickyheadersrecyclerview.StickyRecyclerHeadersAdapter;
 import com.timehop.stickyheadersrecyclerview.StickyRecyclerHeadersDecoration;
 import com.timehop.stickyheadersrecyclerview.StickyRecyclerHeadersTouchListener;
@@ -63,6 +64,13 @@ public class MainActivity extends AppCompatActivity {
 
     // Add the sticky headers decoration
     final StickyRecyclerHeadersDecoration headersDecor = new StickyRecyclerHeadersDecoration(adapter);
+    headersDecor.setOnStickHeaderChangedListener(
+            new HeaderPositionCalculator.StickHeaderChangedListerner() {
+              @Override
+              public void onStickHeaderChanged(View newHeader, View oldHeader) {
+
+              }
+            });
     recyclerView.addItemDecoration(headersDecor);
 
     // Add decoration for dividers between list items

--- a/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/MainActivity.java
+++ b/sample/src/main/java/com/timehop/stickyheadersrecyclerview/sample/MainActivity.java
@@ -82,8 +82,8 @@ public class MainActivity extends AppCompatActivity {
     touchListener.setOnHeaderClickListener(
         new StickyRecyclerHeadersTouchListener.OnHeaderClickListener() {
           @Override
-          public void onHeaderClick(View header, int position, long headerId) {
-            Toast.makeText(MainActivity.this, "Header position: " + position + ", id: " + headerId,
+          public void onHeaderClick(View header, int position, long headerId, boolean currentSticky) {
+            Toast.makeText(MainActivity.this, "Header position: " + position + ", id: " + headerId +", stick: "+ currentSticky,
                 Toast.LENGTH_SHORT).show();
           }
         });


### PR DESCRIPTION
Hi there:

Thanks for this great lib. It really helped us a lot during ur work. And these two more features below are some functions I guess might be useful to other developers who also like to use it during daily work. So, sorry for bothering and please review 😄   

Reason:
1. **[currentSticky]** the position value OnHeaderClickListener returned is not correct when the header view is sticky, it always returns 1. Thus, I guess a way out is adding this 'currentSticky' to Listener's callback. And then when sticky, we can just use recyclerview LayoutManager's `findFirstVisibleItemPosition()`first item to do this hack.
1. **OnStickHeaderChanged()** could be used to change Stick Header's details when header changed

@timehop-deploy @jacobtabak @emanuelet Plz Review 😄 
