### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Download
 
 Current version: [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.timehop.stickyheadersrecyclerview/library/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.timehop.stickyheadersrecyclerview/library)
 
-    compile 'com.timehop.stickyheadersrecyclerview:library:[latest.version.number]@aar'
+    implementation 'com.timehop.stickyheadersrecyclerview:library:[latest.version.number]@aar'
 
 
 Usage


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.